### PR TITLE
Fix compatibility with Test-Fatal 0.016

### DIFF
--- a/t/debug.t
+++ b/t/debug.t
@@ -20,6 +20,7 @@ sub bar {
 }
 
 sub baz {
+    local $Carp::MaxArgNums = 2;
     my $f = shift;
     $f->(@_)
 }
@@ -30,10 +31,10 @@ my $exc = exception { baz $ret, 'ducks'; };
 like $exc, qr{
     .* \bwith_return\b .* \Q${\__FILE__}\E .* \b 14 \b .* \n
     .* \bfoo\b         .* \Q${\__FILE__}\E .* \b 19 \b .* \n
-    .* \bbar\b         .* \Q${\__FILE__}\E .* \b 27 \b .* \n
+    .* \bbar\b         .* \Q${\__FILE__}\E .* \b 28 \b .* \n
 }x;
 
 like $exc, qr{
-    .* \bReturn::MultiLevel\b .* \bducks\b .* \Q${\__FILE__}\E .* \b 24 \b .* \n
-    .* \bbaz\b                .* \bducks\b .* \Q${\__FILE__}\E .* \b 28 \b .* \n
+    .* \bReturn::MultiLevel\b .* \bducks\b .* \Q${\__FILE__}\E .* \b 25 \b .* \n
+    .* \bbaz\b                .* \bducks\b .* \Q${\__FILE__}\E .* \b 29 \b .* \n
 }x;


### PR DESCRIPTION
Test-Fatal 0.016 sets `$Carp::MaxArgNums` to -1, which makes function arguments invisible in the stack trace and this in turn causes `t/debug.t` to fail. To fix this, explicitly set `$Carp::MaxArgNums` to 2 in the test function to restore visibility of function arguments. This change allows the test to work with Test-Fatal 0.016 and also older versions.