### PR TITLE
workaround for rt#133221

### DIFF
--- a/t/debug.t
+++ b/t/debug.t
@@ -25,7 +25,7 @@ sub baz {
 }
 
 my $ret = bar;
-my $exc = exception { baz $ret, 'ducks'; };
+my $exc = exception { local $Carp::MaxArgNums = 8; baz $ret, 'ducks'; };
 
 like $exc, qr{
     .* \bwith_return\b .* \Q${\__FILE__}\E .* \b 14 \b .* \n


### PR DESCRIPTION
Test::Fatal broke this module starting with 0.015.

I traced the commit that broke `Return::MultiLevel` back to https://github.com/rjbs/Test-Fatal/commit/45158215a00659f3e51e2c9092188cd5453ab2e7.  This seems to be an intentional change and not a bug in `Test::Fatal`.  The workaround there suggested is to set `$Carp::MaxArgsNums` to the value that you want.